### PR TITLE
Assume Github OIDC role

### DIFF
--- a/.github/workflows/job-runner.yaml
+++ b/.github/workflows/job-runner.yaml
@@ -31,6 +31,10 @@ on:
         required: false
         default: 'small'
 
+permissions:
+  id-token: write   # This is required for requesting the JWT
+  contents: read    # This is required for actions/checkout
+
 jobs:
   name-job:
     runs-on: ubuntu-latest
@@ -56,6 +60,12 @@ jobs:
     - name: checkout repository
       uses: actions/checkout@v3
 
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v2
+      with:
+        role-to-assume: arn:aws:iam::444055461661:role/github-actions-role-eodc
+        role-session-name: veda-pforge-run-job
+        aws-region: us-west-2
 
     - name: set up python 3.10
       uses: actions/setup-python@v3
@@ -191,12 +201,12 @@ jobs:
     name: monitor job ${{ needs.name-job.outputs.repo_name }}@${{ github.event.inputs.ref }}
     needs: [name-job, run-job]
     steps:
-      - name: set up aws credentials for job runner user
+      - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-access-key-id: ${{ secrets.GH_ACTIONS_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.GH_ACTIONS_AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.GH_ACTIONS_AWS_REGION }}
+          role-to-assume: arn:aws:iam::444055461661:role/github-actions-role-eodc
+          role-session-name: veda-pforge-monitor-job
+          aws-region: us-west-2
 
       - name: install kubectl
         run: |


### PR DESCRIPTION
@ranchodeluxe we already had an OIDC provider and role for EODC projects configured in the VEDA SMCE account called `github-actions-role-eodc`, its just been awhile since I configured it so I forgot. We could also create a new role specifically for this project, but I think that role is well-scoped to EODC projects for now. The trust policy is:

```
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Principal": {
                "Federated": "arn:aws:iam::XXX:oidc-provider/token.actions.githubusercontent.com"
            },
            "Action": "sts:AssumeRoleWithWebIdentity",
            "Condition": {
                "StringEquals": {
                    "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
                },
                "StringLike": {
                    "token.actions.githubusercontent.com:sub": [
                        "repo:developmentseed/tile-benchmarking*",
                        "repo:developmentseed/titiler-xarray*",
                        "repo:developmentseed/titiler-cmr*",
                        "repo:NASA-IMPACT/veda-pforge-job-runner*"
                    ]
                }
            }
        }
    ]
}
```

I also added the EKSFullAccess policy to that role. So I think we should be good to go, as this configuration now looks very similar to what I used for [titiler-xarray](https://github.com/developmentseed/titiler-xarray/blob/dev/.github/workflows/ci.yml) deployments.

I will also remove the obsolete environment variables starting with `GH_*` once this is ✅ 
