### PR TITLE
misc fixes

### DIFF
--- a/.github/workflows/config.py
+++ b/.github/workflows/config.py
@@ -76,7 +76,7 @@ def calc_task_manager_resources(task_manager_process_memory):
 
 resource_profile_choice = os.environ.get("RESOURCE_PROFILE")
 task_manager_process_memory_map = {
-    "small": 7168,
+    "small": 5632,
     "medium": 10240,
     "large": 15360,
     "xlarge": 20480,

--- a/.github/workflows/job-runner.yaml
+++ b/.github/workflows/job-runner.yaml
@@ -26,8 +26,11 @@ on:
         description: 'What auth mode (edl or iamrole) to use when accessing files.'
         required: false
         default: 'iamrole'
+      job_name:
+        description: 'A unique job name (no other existing filnk deployment can have it) so we can inspect metrics easier in Grafana.'
+        required: true
       resource_profile:
-        description: 'jobs have different memory requirements so choose (small[7168M], medium[10240M], large[15360M], xlarge[20480M])'
+        description: 'jobs have different memory requirements so choose (small[5632M], medium[10240M], large[15360M], xlarge[20480M])'
         required: false
         default: 'small'
 
@@ -106,6 +109,7 @@ jobs:
           bake \
           --repo=${{ github.event.inputs.repo }} \
           --ref=${{ github.event.inputs.ref }} \
+          --Bake.job_name=${{ github.event.inputs.repo }} \
           -f .github/workflows/config.py > execute.log
 
         # export all the valuable information from the logs
@@ -192,6 +196,7 @@ jobs:
   monitor-job:
     runs-on: ubuntu-latest
     name: monitor job ${{ needs.name-job.outputs.repo_name }}@${{ github.event.inputs.ref }}
+    environment: veda-smce
     needs: [name-job, run-job]
     steps:
       - name: Configure AWS credentials


### PR DESCRIPTION
* add correct `environment:` key on missing `monitor-job` job
* constrain memory usage if we're sticking with `t3.large`
* require a `job_name` to be passed for better metrics searching