### PR TITLE
gc/patch/remove caching

### DIFF
--- a/.github/workflows/config.py
+++ b/.github/workflows/config.py
@@ -76,10 +76,10 @@ def calc_task_manager_resources(task_manager_process_memory):
 
 resource_profile_choice = os.environ.get("RESOURCE_PROFILE")
 task_manager_process_memory_map = {
-    "small": 5632,
-    "medium": 10240,
-    "large": 15360,
-    "xlarge": 20480,
+    "small": 7824,
+    "medium": 9824,
+    "large": 11824,
+    "xlarge": 13824,
 }
 if resource_profile_choice not in list(task_manager_process_memory_map.keys()):
     raise ValueError(
@@ -100,7 +100,7 @@ c.Bake.feedstock_subdir = os.environ.get("FEEDSTOCK_SUBDIR")
 c.FlinkOperatorBakery.parallelism = int(os.environ.get("PARALLELISM_OPTION"))
 c.FlinkOperatorBakery.enable_job_archiving = False
 c.FlinkOperatorBakery.flink_version = "1.16"
-c.FlinkOperatorBakery.job_manager_resources = {"memory": "1536m", "cpu": 0.3}
+c.FlinkOperatorBakery.job_manager_resources = {"memory": "1280m", "cpu": 0.3}
 c.FlinkOperatorBakery.task_manager_resources = {
     "memory": f"{task_manager_process_memory_map[resource_profile_choice]}m",
     "cpu": 0.3

--- a/.github/workflows/config.py
+++ b/.github/workflows/config.py
@@ -121,6 +121,6 @@ c.TargetStorage.fsspec_args = {
     "client_kwargs": {"region_name": "us-west-2"},
 }
 
-c.InputCacheStorage.fsspec_class = c.TargetStorage.fsspec_class
-c.InputCacheStorage.fsspec_args = c.TargetStorage.fsspec_args
-c.InputCacheStorage.root_path = f"{BUCKET_PREFIX}/cache/"
+# c.InputCacheStorage.fsspec_class = c.TargetStorage.fsspec_class
+# c.InputCacheStorage.fsspec_args = c.TargetStorage.fsspec_args
+# c.InputCacheStorage.root_path = f"{BUCKET_PREFIX}/cache/"

--- a/.github/workflows/job-runner.yaml
+++ b/.github/workflows/job-runner.yaml
@@ -30,7 +30,7 @@ on:
         description: 'A unique job name (no other existing filnk deployment can have it) so we can inspect metrics easier in Grafana.'
         required: true
       resource_profile:
-        description: 'jobs have different memory requirements so choose (small[5632M], medium[10240M], large[15360M], xlarge[20480M])'
+        description: 'jobs have different memory requirements so choose (small[7824_MiB], medium[9824_MiB], large[11824_MiB], xlarge[13824_MiB])'
         required: false
         default: 'small'
 

--- a/.github/workflows/job-runner.yaml
+++ b/.github/workflows/job-runner.yaml
@@ -109,7 +109,7 @@ jobs:
           bake \
           --repo=${{ github.event.inputs.repo }} \
           --ref=${{ github.event.inputs.ref }} \
-          --Bake.job_name=${{ github.event.inputs.repo }} \
+          --Bake.job_name="${{ github.event.inputs.job_name }}" \
           -f .github/workflows/config.py > execute.log
 
         # export all the valuable information from the logs

--- a/.github/workflows/job-runner.yaml
+++ b/.github/workflows/job-runner.yaml
@@ -64,7 +64,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v2
+      uses: aws-actions/configure-aws-credentials@v3
       with:
         role-to-assume: arn:aws:iam::444055461661:role/github-actions-role-eodc
         role-session-name: veda-pforge-run-job
@@ -200,10 +200,11 @@ jobs:
     needs: [name-job, run-job]
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v3
         with:
           role-to-assume: arn:aws:iam::444055461661:role/github-actions-role-eodc
           role-session-name: veda-pforge-monitor-job
+          role-duration-seconds: 21600  # note this has to match our timeout-minutes below for monitoring
           aws-region: us-west-2
 
       - name: install kubectl
@@ -221,7 +222,7 @@ jobs:
 #
       - name: monitor logs of job manager and report final status
         id: monitorjob
-        timeout-minutes: 240
+        timeout-minutes: 360
         continue-on-error: true
         run: |
           # TODO: this needs to not check the logs but the historyserver status


### PR DESCRIPTION
* Raphael and I noticed on our last run that the first two hours of the job was just moving the s3 file from origin to cache 😞 It was too slow so we comment out caching here and that helps and should be find as long as our origin is s3

<img width="1792" alt="Screen Shot 2024-03-06 at 1 46 22 PM" src="https://github.com/NASA-IMPACT/veda-pforge-job-runner/assets/208859/fc376344-5246-4f16-be15-b11d24ba4556">

* The monitor job was working fine and then mysteriously after an hour lost credentials so adding `role-durations-seconds` works

* Bump aws credentials to v3

* Force a required `job_name`

* New resourcing b/c we need more than 2GB at least to run some of these recipes
