### PR TITLE
Build hdf5 clibs; install xarray deps for netcdf

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.46.0"
   constraints = ">= 4.62.0, >= 5.30.0"
   hashes = [
+    "h1:d0Mf33mbbQujZ/JaYkqmH5gZGvP+iEIWf9yBSiOwimE=",
     "h1:gagAtniijwJRhsKRBWWZfmnPiqu4u1A5oI626+KA/1g=",
     "zh:05ae6180a7f23071435f6e5e59c19af0b6c5da42ee600c6c1568c8660214d548",
     "zh:0d878d1565d5e57ce6b34ec5f04b28662044a50c999ec5770c374aa1f1020de2",
@@ -28,6 +29,7 @@ provider "registry.terraform.io/hashicorp/external" {
   version = "2.3.3"
   hashes = [
     "h1:Qi72kOSrEYgEt5itloFhDfmiFZ7wnRy3+F74XsRuUOw=",
+    "h1:gShzO1rJtADK9tDZMvMgjciVAzsBh39LNjtThCwX1Hg=",
     "zh:03d81462f9578ec91ce8e26f887e34151eda0e100f57e9772dbea86363588239",
     "zh:37ec2a20f6a3ec3a0fd95d3f3de26da6cb9534b30488bc45723e118a0911c0d8",
     "zh:4eb5b119179539f2749ce9de0e1b9629d025990f062f4f4dddc161562bb89d37",
@@ -46,6 +48,7 @@ provider "registry.terraform.io/hashicorp/external" {
 provider "registry.terraform.io/hashicorp/null" {
   version = "3.2.2"
   hashes = [
+    "h1:IMVAUHKoydFrlPrl9OzasDnw/8ntZFerCC9iXw1rXQY=",
     "h1:vWAsYRd7MjYr3adj8BVKRohVfHpWQdvkIwUQ2Jf5FVM=",
     "zh:3248aae6a2198f3ec8394218d05bd5e42be59f43a3a7c0b71c66ec0df08b69e7",
     "zh:32b1aaa1c3013d33c245493f4a65465eab9436b454d250102729321a44c8ab9a",
@@ -59,22 +62,5 @@ provider "registry.terraform.io/hashicorp/null" {
     "zh:aa9015926cd152425dbf86d1abdbc74bfe0e1ba3d26b3db35051d7b9ca9f72ae",
     "zh:bb04798b016e1e1d49bcc76d62c53b56c88c63d6f2dfe38821afef17c416a0e1",
     "zh:c23084e1b23577de22603cff752e59128d83cfecc2e6819edadd8cf7a10af11e",
-  ]
-}
-
-provider "registry.terraform.io/hashicorp/template" {
-  version = "2.2.0"
-  hashes = [
-    "h1:0wlehNaxBX7GJQnPfQwTNvvAf38Jm0Nv7ssKGMaG6Og=",
-    "zh:01702196f0a0492ec07917db7aaa595843d8f171dc195f4c988d2ffca2a06386",
-    "zh:09aae3da826ba3d7df69efeb25d146a1de0d03e951d35019a0f80e4f58c89b53",
-    "zh:09ba83c0625b6fe0a954da6fbd0c355ac0b7f07f86c91a2a97849140fea49603",
-    "zh:0e3a6c8e16f17f19010accd0844187d524580d9fdb0731f675ffcf4afba03d16",
-    "zh:45f2c594b6f2f34ea663704cc72048b212fe7d16fb4cfd959365fa997228a776",
-    "zh:77ea3e5a0446784d77114b5e851c970a3dde1e08fa6de38210b8385d7605d451",
-    "zh:8a154388f3708e3df5a69122a23bdfaf760a523788a5081976b3d5616f7d30ae",
-    "zh:992843002f2db5a11e626b3fc23dc0c87ad3729b3b3cff08e32ffb3df97edbde",
-    "zh:ad906f4cebd3ec5e43d5cd6dc8f4c5c9cc3b33d2243c89c5fc18f97f7277b51d",
-    "zh:c979425ddb256511137ecd093e23283234da0154b7fa8b21c2687182d9aea8b2",
   ]
 }

--- a/terraform/docker/Dockerfile
+++ b/terraform/docker/Dockerfile
@@ -53,10 +53,10 @@ RUN pip3 install \
   venvception>=0.0.5 \
   jupyter-repo2docker \
   pangeo-forge-recipes \
-  git+https://github.com/ranchodeluxe/beam-pyspark-runner@patch-2 \
-  h5py \
   netcdf4 \
-  wheel && \
+  h5netcdf \
+  wheel \
+  git+https://github.com/ranchodeluxe/beam-pyspark-runner@patch-2 && \
   HDF5_MPI="ON" HDF5_DIR=/usr pip3 install --no-binary=h5py h5py
 
 WORKDIR /home/hadoop

--- a/terraform/docker/Dockerfile
+++ b/terraform/docker/Dockerfile
@@ -3,8 +3,36 @@ FROM public.ecr.aws/emr-serverless/spark/emr-7.0.0:latest
 USER root
 WORKDIR /opt
 
-RUN yum update -y && yum install -y git
 
+# Update and install required packages
+RUN dnf update -y && \
+    dnf install -y \
+    git \
+    gcc \
+    gcc-c++ \
+    make \
+    wget \
+    zlib-devel \
+    python3-devel && \
+    dnf clean all
+
+
+# Download and build HDF5 from source with thread safety and parallel enabled
+RUN wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.14/hdf5-1.14.3/src/hdf5-1.14.3.tar.gz && \
+    tar -xzf hdf5-1.14.3.tar.gz && \
+    cd hdf5-1.14.3 && \
+    ./configure --prefix=/usr --disable-fortran --enable-hl --with-zlib=/usr/include,/usr/lib && \
+    make -j -l6 && \
+    make install && \
+    cd .. && \
+    rm -rf hdf5-1.14.3 hdf5-1.14.3.tar.gz
+
+# Set the HDF5 library path
+ENV HDF5_DIR=/usr
+ENV LD_LIBRARY_PATH=/usr/lib:$LD_LIBRARY_PATH
+ENV CPATH=/usr/include:$CPATH
+
+# Install Python packages
 RUN pip3 install \
   s3fs \
   gcsfs \
@@ -16,7 +44,11 @@ RUN pip3 install \
   venvception>=0.0.5 \
   jupyter-repo2docker \
   pangeo-forge-recipes \
-  git+https://github.com/ranchodeluxe/beam-pyspark-runner@patch-2
+  git+https://github.com/ranchodeluxe/beam-pyspark-runner@patch-2 \
+  h5py \
+  netcdf4 \
+  wheel && \
+  HDF5_DIR=/usr pip3 install --no-binary=h5py h5py
 
 WORKDIR /home/hadoop
 USER hadoop:hadoop

--- a/terraform/docker/Dockerfile
+++ b/terraform/docker/Dockerfile
@@ -13,15 +13,24 @@ RUN dnf update -y && \
     make \
     wget \
     zlib-devel \
+    openmpi-devel \
     python3-devel && \
     dnf clean all
 
+
+# Set up MPI environment
+ENV PATH=/usr/lib64/openmpi/bin:$PATH
+ENV LD_LIBRARY_PATH=/usr/lib64/openmpi/lib:$LD_LIBRARY_PATH
+ENV CPATH=/usr/lib64/openmpi/include:$CPATH
+ENV MPI_CC=mpicc
+
+RUN pip3 install mpi4py
 
 # Download and build HDF5 from source with thread safety and parallel enabled
 RUN wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.14/hdf5-1.14.3/src/hdf5-1.14.3.tar.gz && \
     tar -xzf hdf5-1.14.3.tar.gz && \
     cd hdf5-1.14.3 && \
-    ./configure --prefix=/usr --disable-fortran --enable-hl --with-zlib=/usr/include,/usr/lib && \
+    ./configure --prefix=/usr --disable-fortran --enable-hl --enable-parallel --with-zlib=/usr/include,/usr/lib CPPFLAGS=-I/usr/include/openmpi-aarch64 && \
     make -j -l6 && \
     make install && \
     cd .. && \
@@ -30,7 +39,7 @@ RUN wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.14/hdf5-1.14.3/sr
 # Set the HDF5 library path
 ENV HDF5_DIR=/usr
 ENV LD_LIBRARY_PATH=/usr/lib:$LD_LIBRARY_PATH
-ENV CPATH=/usr/include:$CPATH
+ENV CPATH=/usr/include:/usr/include/openmpi-aarch64:$CPATH
 
 # Install Python packages
 RUN pip3 install \
@@ -48,7 +57,7 @@ RUN pip3 install \
   h5py \
   netcdf4 \
   wheel && \
-  HDF5_DIR=/usr pip3 install --no-binary=h5py h5py
+  HDF5_MPI="ON" HDF5_DIR=/usr pip3 install --no-binary=h5py h5py
 
 WORKDIR /home/hadoop
 USER hadoop:hadoop

--- a/terraform/emr/main.tf
+++ b/terraform/emr/main.tf
@@ -74,13 +74,11 @@ resource "aws_ecr_repository_policy" "emr_serverless_ecr_policy" {
 }
 
 # Execution role (permissions for actual job runs)
-data "template_file" "execution_role_policy" {
-  template = file(var.execution_role_template)
-
-  vars = {
-    region = var.region
+locals {
+  execution_role_policy = templatefile(var.execution_role_template, {
+    region     = var.region
     account_id = var.account_id
-  }
+  })
 }
 
 resource "aws_iam_policy" "emr_execution_policy" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -9,7 +9,7 @@ provider "aws" {
 }
 
 terraform {
-  required_version = "1.7.4"
+  required_version = "~> 1.7.4"
   required_providers {
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
This should enable use of the most up-to-date netcdf drivers in EMR serverless processes. I've also modified the `required_version` for terraform's main file to work with terraform above 1.7.4 but below 1.8.0